### PR TITLE
Improvement: Raise data checking rate

### DIFF
--- a/tracer_base/include/tracer_base/tracer_messenger.hpp
+++ b/tracer_base/include/tracer_base/tracer_messenger.hpp
@@ -88,6 +88,9 @@ class TracerMessenger {
 
     auto time_offset = node_->now().nanoseconds() -
                        static_cast<double>(convert_sdkclock_to_uint64_epoch_nano(SdkClock::now()));
+
+    tracer_msgs::msg::TracerStatus status_msg;
+
     status_msg.header.stamp =
         rclcpp::Time(time_offset + static_cast<double>(actuator_stamp));
 
@@ -116,10 +119,6 @@ class TracerMessenger {
     }
 
     auto state = tracer_->GetRobotState();
-
-    // publish tracer state message
-    tracer_msgs::msg::TracerStatus status_msg;
-
     //status_msg.header.stamp = current_time_;
 
     status_msg.linear_velocity = state.motion_state.linear_velocity;

--- a/tracer_base/src/tracer_base_ros.cpp
+++ b/tracer_base/src/tracer_base_ros.cpp
@@ -116,7 +116,7 @@ void TracerBaseRos::Run() {
   // publish robot state at 50Hz while listening to twist commands
   messenger->SetupSubscription();
   keep_running_ = true;
-  rclcpp::Rate rate(50);
+  rclcpp::Rate rate(200);
   while (keep_running_) {
     messenger->PublishStateToROS();
     rclcpp::spin_some(shared_from_this());


### PR DESCRIPTION
Tracer에서 left actuator와 right actuator가 각각 50hz로 나오고 있는데, actuator 데이터를 체크하는 timer가 똑같이 50hz로 작동하면 데이터를 놓치는 경우가 발생합니다.

이를 해결하기 위해서, 200hz로 data를 확인하고 timestamp가 업데이트 되지 않았으면 message는 publish하지 않는 방식으로 해결하였습니다.

지난 모비어스 데모 때 수정인데 빠뜨렸습니다.